### PR TITLE
add config for Travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+go: 1.12
+go_import_path: github.com/romantomjak/shoutcast
+
+install: true
+
+script: go test


### PR DESCRIPTION
The default setup of Travis does not work because it tries to install the example's dependencies which fails on the plain test machine. Therefore the default installation is skipped and tests are run explicitly via `script`.