### PR TITLE
Bugfixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: go
 go: 1.12
 go_import_path: github.com/romantomjak/shoutcast
 
-install: go get github.com/stretchr/testify
+install: true
 
 script: go test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: go
 go: 1.12
 go_import_path: github.com/romantomjak/shoutcast
 
-install: true
+install: go get github.com/stretchr/testify
 
 script: go test

--- a/stream.go
+++ b/stream.go
@@ -128,6 +128,8 @@ func (s *Stream) Read(p []byte) (n int, err error) {
 			}
 			if mn == metadataLength {
 				metadataRead = true
+			} else if err == nil || err == io.EOF {
+				err = io.ErrUnexpectedEOF
 			}
 			n = metadataStart
 			// If we fail in the middle of a metadata block this is not really correct. But then the

--- a/stream.go
+++ b/stream.go
@@ -70,9 +70,12 @@ func Open(url string) (*Stream, error) {
 		log.Print("[DEBUG] HTTP header ", k, ": ", v[0])
 	}
 
-	bitrate, err := strconv.Atoi(resp.Header.Get("icy-br"))
-	if err != nil {
-		return nil, fmt.Errorf("cannot parse bitrate: %v", err)
+	var bitrate int
+	if rawBitrate := resp.Header.Get("icy-br"); rawBitrate != "" {
+		bitrate, err = strconv.Atoi(rawBitrate)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse bitrate: %v", err)
+		}
 	}
 
 	metaint, err := strconv.Atoi(resp.Header.Get("icy-metaint"))

--- a/stream_test.go
+++ b/stream_test.go
@@ -116,7 +116,6 @@ func TestUnexpectedEOF(t *testing.T) {
 
 		metadata := makeMetadata("SongTitle='Prospa Prayer';")
 		stream := insertMetadata([]byte{1, 1}, metadata, 1)
-		// fmt.Printf("%v\n", stream)
 		// unexpected EOF in the middle of a metadata block
 		w.Write(stream[:len(stream)-10])
 	}))
@@ -130,7 +129,7 @@ func TestUnexpectedEOF(t *testing.T) {
 		assertEqual(t, []byte{1}, b1)
 	}
 
-	// The metadata is immediatly read and does not fit into the buffer.
+	// The metadata is read immediately and does not fit into the buffer.
 	// -> `0, nil` is returned.
 	// Filling the buffer after the reading of the metadata would be more complexity without advantage.
 	n, err = s.Read(b1)
@@ -143,7 +142,7 @@ func TestUnexpectedEOF(t *testing.T) {
 		assertEqual(t, []byte{1}, b2)
 	}
 
-	// ooops, nothing to read
+	// oops, nothing to read
 	b3 := make([]byte, 1)
 	n, err = s.Read(b3)
 	assertEqual(t, 0, n)
@@ -159,7 +158,6 @@ func TestMetaintEqualsClientBufferLength(t *testing.T) {
 
 		metadata := makeMetadata("SongTitle='Prospa Prayer';")
 		stream := insertMetadata([]byte{1, 1, 1, 1, 1, 1}, metadata, 2)
-		// fmt.Printf("%v\n", stream)
 		w.Write(stream)
 	}))
 	defer ts.Close()
@@ -172,7 +170,7 @@ func TestMetaintEqualsClientBufferLength(t *testing.T) {
 		assertEqual(t, []byte{1, 1}, b1)
 	}
 
-	// The metadata is immediatly read and does not fit into the buffer.
+	// The metadata is read immediately and does not fit into the buffer.
 	// -> `0, nil` is returned.
 	// Filling the buffer after the reading of the metadata would be more complexity without advantage.
 	n, err = s.Read(b1)
@@ -211,7 +209,6 @@ func TestMetaintGreaterThanClientBufferLength(t *testing.T) {
 
 		metadata := makeMetadata("SongTitle='Prospa Prayer';")
 		stream := insertMetadata([]byte{1, 1, 1, 1, 1, 1}, metadata, 3)
-		// fmt.Printf("%v\n", stream)
 		w.Write(stream)
 	}))
 	defer ts.Close()

--- a/stream_test.go
+++ b/stream_test.go
@@ -93,7 +93,8 @@ func TestUnexpectedEOF(t *testing.T) {
 		metadata := makeMetadata("SongTitle='Prospa Prayer';")
 		stream := insertMetadata([]byte{1, 1}, metadata, 1)
 		// fmt.Printf("%v\n", stream)
-		w.Write(stream)
+		// unexpected EOF in the middle of a metadata block
+		w.Write(stream[:len(stream)-10])
 	}))
 	defer ts.Close()
 
@@ -123,7 +124,7 @@ func TestUnexpectedEOF(t *testing.T) {
 	n, err = s.Read(b3)
 	assert.Equal(t, 0, n)
 	if assert.Error(t, err) {
-		assert.Equal(t, io.EOF, err)
+		assert.Equal(t, io.ErrUnexpectedEOF, err)
 	}
 }
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func assertStrings(t *testing.T, got, want string) {
@@ -71,6 +73,16 @@ func TestRequiredHTTPHeadersArePresent(t *testing.T) {
 
 	assertStrings(t, headers.Get("icy-metadata"), "1")
 	assertStrings(t, headers.Get("user-agent")[:6], "iTunes")
+}
+
+func TestMissingBitrate(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header()["icy-metaint"] = []string{"100"}
+		w.WriteHeader(200)
+	}))
+
+	_, err := Open(ts.URL)
+	assert.NoError(t, err)
 }
 
 func TestUnexpectedEOF(t *testing.T) {


### PR DESCRIPTION
this PR fixes the following bugs and adds/fixes some tests:

- failure if server did not send a bitrate
- failure if metadata block did not fit into the buffer to read into
- failure if the buffer to read into is large enough for multiple metadata blocks